### PR TITLE
update spy url

### DIFF
--- a/swim_testnet/spy.yaml
+++ b/swim_testnet/spy.yaml
@@ -47,7 +47,7 @@ spec:
             - /wormhole/testnet/2/1
             # Hardcoded testnet bootstrap from relayer/spy_relayer/README.md
             - --bootstrap
-            - /dns4/wormhole-testnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWBY9ty9CXLBXGQzMuqkziLntsVcyz4pk1zWaJRvJn6Mmt
+            - /dns4/wormhole-testnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWAkB9ynDur1Jtoa97LBUp8RXdhzS5uHgAfdTquJbrbN7i
 #            - --logLevel=debug
           ports:
             - containerPort: 7073


### PR DESCRIPTION
The bootstrap for testnet changed https://github.com/wormhole-foundation/wormhole/commit/7fbffe424d0ab6fefb0c98ba7f222d0ee8d599cf